### PR TITLE
range minimum should be treated inclusively by the random integer method

### DIFF
--- a/lib/rand.js
+++ b/lib/rand.js
@@ -72,7 +72,7 @@ module.exports.int = function(opts) {
 	if (! opts.min && ! opts.max) {
 		return 0;
 	}
-	ret = Math.floor(module.exports.double(opts.gen) * (opts.max + opts.min) + 1) - opts.min;
+	ret = Math.floor(module.exports.double(opts.gen) * (opts.max + opts.min)) - opts.min;
 	if (ret === opts.max) {
 		ret--;
 	}

--- a/lib/rand.js
+++ b/lib/rand.js
@@ -73,7 +73,7 @@ module.exports.int = function(opts) {
 		return 0;
 	}
 	ret = Math.floor(module.exports.double(opts.gen) * (opts.max + opts.min)) - opts.min;
-	if (ret === opts.max) {
+	if (ret === (opts.max || 1)) {
 		ret--;
 	}
 	return ret;


### PR DESCRIPTION
I believe this resolves https://github.com/kbjr/node-cards/issues/6. `module.exports.int` never returned `0` unless a max of `1` was passed in - in which case, the 2 of clubs was always swapped into array index 1.
